### PR TITLE
Add update prompt bypass for completion command

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -43,6 +43,14 @@ const logo string = `
 // Execute adds all child commands to the root command and sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute() {
+	if len(os.Args) > 1 && os.Args[1] == "completion" {
+		err := rootCmd.Execute()
+		cobra.CheckErr(err)
+		if err != nil {
+			os.Exit(1)
+		}
+		return
+	}
 	err := checks.PromptUpdateIfNecessary(rootCmd.Version)
 	cobra.CheckErr(err)
 	err = rootCmd.Execute()


### PR DESCRIPTION
These changes address issue #6 

This modification forces the CLI application to not print the update prompt when issuing completion commands by checking os.Args for "completion" before checking if the CLI tool is not latest.