### PR TITLE
WIP:rename assignments to lessons

### DIFF
--- a/checks/http.go
+++ b/checks/http.go
@@ -24,13 +24,13 @@ type HttpTestResult struct {
 }
 
 func HttpTest(
-	assignment api.Assignment,
+	lesson api.Lesson,
 	baseURL *string,
 ) (
 	responses []HttpTestResult,
 	finalBaseURL string,
 ) {
-	data := assignment.Assignment.AssignmentDataHTTPTests
+	data := lesson.Lesson.LessonDataHTTPTests
 	client := &http.Client{}
 	variables := make(map[string]string)
 	responses = make([]HttpTestResult, len(data.HttpTests.Requests))

--- a/client/assignments.go
+++ b/client/assignments.go
@@ -38,10 +38,10 @@ type HTTPTestHeader struct {
 	Value string
 }
 
-type Assignment struct {
-	Assignment struct {
-		Type                    string
-		AssignmentDataHTTPTests *struct {
+type Lesson struct {
+	Lesson struct {
+		Type                string
+		LessonDataHTTPTests *struct {
 			HttpTests struct {
 				BaseURL             *string
 				ContainsCompleteDir bool
@@ -67,13 +67,13 @@ type Assignment struct {
 	}
 }
 
-func FetchAssignment(uuid string) (*Assignment, error) {
+func FetchLesson(uuid string) (*Lesson, error) {
 	resp, err := fetchWithAuth("GET", "/v1/assignments/"+uuid)
 	if err != nil {
 		return nil, err
 	}
 
-	var data Assignment
+	var data Lesson
 	err = json.Unmarshal(resp, &data)
 	if err != nil {
 		return nil, err
@@ -91,7 +91,7 @@ type submitHTTPTestRequest struct {
 	ActualHTTPRequests any `json:"actualHTTPRequests"`
 }
 
-func SubmitHTTPTestAssignment(uuid string, results any) error {
+func SubmitHTTPTestLesson(uuid string, results any) error {
 	bytes, err := json.Marshal(submitHTTPTestRequest{ActualHTTPRequests: results})
 	if err != nil {
 		return err

--- a/client/auth.go
+++ b/client/auth.go
@@ -61,6 +61,7 @@ func LoginWithCode(code string) (*LoginResponse, error) {
 	}
 
 	if resp.StatusCode == 403 {
+		//lint:ignore ST1005 "ok"
 		return nil, errors.New("The code you entered was invalid. Try refreshing your browser and trying again.")
 	}
 

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -17,21 +17,21 @@ func init() {
 var runCmd = &cobra.Command{
 	Use:    "run UUID",
 	Args:   cobra.ExactArgs(1),
-	Short:  "Run an assignment without submitting",
+	Short:  "Run an lesson without submitting",
 	PreRun: compose(requireUpdated, requireAuth),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
-		assignmentUUID := args[0]
-		assignment, err := api.FetchAssignment(assignmentUUID)
+		lessonUUID := args[0]
+		lesson, err := api.FetchLesson(lessonUUID)
 		if err != nil {
 			return err
 		}
-		if assignment.Assignment.Type == "type_http_tests" {
-			results, finalBaseURL := checks.HttpTest(*assignment, &runBaseURL)
-			printResults(results, assignment, finalBaseURL)
+		if lesson.Lesson.Type == "type_http_tests" {
+			results, finalBaseURL := checks.HttpTest(*lesson, &runBaseURL)
+			printResults(results, lesson, finalBaseURL)
 			cobra.CheckErr(err)
 		} else {
-			cobra.CheckErr("unsupported assignment type")
+			cobra.CheckErr("unsupported this lesson type")
 		}
 		return nil
 	},

--- a/cmd/submit.go
+++ b/cmd/submit.go
@@ -20,36 +20,37 @@ func init() {
 var submitCmd = &cobra.Command{
 	Use:    "submit UUID",
 	Args:   cobra.MatchAll(cobra.ExactArgs(1)),
-	Short:  "Submit an assignment",
+	Short:  "Submit an lesson",
 	PreRun: compose(requireUpdated, requireAuth),
 	Run: func(cmd *cobra.Command, args []string) {
-		assignmentUUID := args[0]
-		assignment, err := api.FetchAssignment(assignmentUUID)
+		lessonUUID := args[0]
+		lesson, err := api.FetchLesson(lessonUUID)
 		cobra.CheckErr(err)
-		if assignment.Assignment.Type == "type_http_tests" {
-			results, finalBaseURL := checks.HttpTest(*assignment, &sbumitBaseURL)
-			printResults(results, assignment, finalBaseURL)
+		fmt.Println(lesson.Lesson.Type)
+		if lesson.Lesson.Type == "type_http_tests" {
+			results, finalBaseURL := checks.HttpTest(*lesson, &sbumitBaseURL)
+			printResults(results, lesson, finalBaseURL)
 			cobra.CheckErr(err)
-			err := api.SubmitHTTPTestAssignment(assignmentUUID, results)
+			err := api.SubmitHTTPTestLesson(lessonUUID, results)
 			cobra.CheckErr(err)
 			fmt.Println("\nSubmitted! Check the lesson on Boot.dev for results")
 		} else {
-			cobra.CheckErr("unsupported assignment type")
+			cobra.CheckErr("unsupported lesson type")
 		}
 	},
 }
 
-func printResults(results []checks.HttpTestResult, assignment *api.Assignment, finalBaseURL string) {
+func printResults(results []checks.HttpTestResult, lesson *api.Lesson, finalBaseURL string) {
 	fmt.Println("=====================================")
 	defer fmt.Println("=====================================")
 	fmt.Printf("Running requests against: %s\n", finalBaseURL)
 	for i, result := range results {
-		printResult(result, i, assignment)
+		printResult(result, i, lesson)
 	}
 }
 
-func printResult(result checks.HttpTestResult, i int, assignment *api.Assignment) {
-	req := assignment.Assignment.AssignmentDataHTTPTests.HttpTests.Requests[i]
+func printResult(result checks.HttpTestResult, i int, lesson *api.Lesson) {
+	req := lesson.Lesson.LessonDataHTTPTests.HttpTests.Requests[i]
 	fmt.Printf("%v. %v %v\n", i+1, req.Request.Method, req.Request.Path)
 	if result.Err != "" {
 		fmt.Printf("  Err: %v\n", result.Err)


### PR DESCRIPTION
The Assignment struct is supposed to be renamed to Lesson, so the parts of the CLI that use "assignment" need to be changed as well, unless this ticket (https://github.com/orgs/bootdotdev/projects/5?pane=issue&itemId=59952759) gets canceled.

This is all tentative, I'm not saying this should change, I'm just showing what would have to change. If it's changing, the sooner, the better, I'd imagine.