### PR TITLE
On README.md, fix reference to bootdev CLI command

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Run `bootdev --version` on your command line to make sure the installation worke
 
 **Optional troubleshooting:**
 
-If you're getting a "command not found" error for `bootdev help`, it's most likely because the directory containing the `bootdev` program isn't in your [`PATH`](https://opensource.com/article/17/6/set-path-linux). You need to add the directory to your `PATH` by modifying your shell's configuration file. You probably need to add `$HOME/go/bin` (the default `GOBIN` directory where `go` installs programs) to your `PATH`:
+If you're getting a "command not found" error for `bootdev --version`, it's most likely because the directory containing the `bootdev` program isn't in your [`PATH`](https://opensource.com/article/17/6/set-path-linux). You need to add the directory to your `PATH` by modifying your shell's configuration file. You probably need to add `$HOME/go/bin` (the default `GOBIN` directory where `go` installs programs) to your `PATH`:
 
 ```bash
 # For Linux/WSL


### PR DESCRIPTION
The README.md mentions running `bootdev --version`, not `bootdev help`. Smol change :P