### PR TITLE
feat: XDG_CONFIG_HOME support

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Run `bootdev login` to authenticate with your Boot.dev account. After authentica
 
 ## Configuration
 
-The Boot.dev CLI offers a couple of configuration options that are stored in a config file (default is `~/.bootdev.yaml`).
+The Boot.dev CLI offers a couple of configuration options that are stored in a config file (default is `~/.bootdev.yaml` or `$XDG_CONFIG_HOME/bootdev/config.yaml`).
 
 All commands have `-h`/`--help` flags if you want to see available options on the command line.
 


### PR DESCRIPTION
If a user has already set the `XDG_CONFIG_HOME` environment variable, they usually expect config to be placed there.

This change allows users who set the variable to take advantage of it while not breaking existing users' experience in any way.