### PR TITLE
print when cli is running something

### DIFF
--- a/messages/messages.go
+++ b/messages/messages.go
@@ -1,0 +1,29 @@
+package messages
+
+import api "github.com/bootdotdev/bootdev/client"
+
+type StartStepMsg struct {
+	ResponseVariables []api.HTTPRequestResponseVariable
+	CMD               string
+	URL               string
+	Method            string
+}
+
+type StartTestMsg struct {
+	Text string
+}
+
+type ResolveTestMsg struct {
+	Index  int
+	Passed *bool
+}
+
+type DoneStepMsg struct {
+	Failure *api.VerificationResultStructuredErrCLI
+}
+
+type ResolveStepMsg struct {
+	Index  int
+	Passed *bool
+	Result *api.CLIStepResult
+}


### PR DESCRIPTION
closes: https://github.com/bootdotdev/go-api-gate/issues/5523

**Most of the change was moving things around.**

An example of a long-running CLI test:

https://github.com/user-attachments/assets/90ec6ec1-a4c6-4582-aa3d-57ac7a2bf4a5




An  example of an HTTP test:

https://github.com/user-attachments/assets/f1e5f2ea-7d25-4078-b4fc-646e790355d1

