### PR TITLE
docs: add go/bin troubleshooting for fish shell

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ After installing Golang, _open a new shell session_ and run `go version` to make
   source ~/.bashrc
   ```
 
-  ```fish
+  ```sh
   # For fish
   fish_add_path $HOME/go/bin
   ```
@@ -88,14 +88,19 @@ Run `bootdev --version` on your command line to make sure the installation worke
 If you're getting a "command not found" error for `bootdev help`, it's most likely because the directory containing the `bootdev` program isn't in your [`PATH`](https://opensource.com/article/17/6/set-path-linux). You need to add the directory to your `PATH` by modifying your shell's configuration file. You probably need to add `$HOME/go/bin` (the default `GOBIN` directory where `go` installs programs) to your `PATH`:
 
 ```sh
-# For Linux/WSL
+# For Linux/WSL/bash
 echo 'export PATH=$PATH:$HOME/go/bin' >> ~/.bashrc
 # Next, reload your shell configuration
 source ~/.bashrc
 ```
 
 ```sh
-# For macOS
+# For fish
+fish_add_path $HOME/go/bin
+```
+
+```sh
+# For macOS/zsh
 echo 'export PATH=$PATH:$HOME/go/bin' >> ~/.zshrc
 # Next, reload your shell configuration
 source ~/.zshrc

--- a/README.md
+++ b/README.md
@@ -55,14 +55,19 @@ After installing Golang, _open a new shell session_ and run `go version` to make
   You can ensure that the program exists by attempting to run `go` using its full filepath. For example, if you think it's in `~/.local/opt/go/bin`, you can run `~/.local/opt/go/bin/go version`. If that works, then you just need to add `~/.local/opt/go/bin` to your `PATH` and reload your shell:
 
   ```sh
-  # For Linux/WSL
+  # For Linux/WSL/bash
   echo 'export PATH=$PATH:$HOME/.local/opt/go/bin' >> ~/.bashrc
   # Next, reload your shell configuration
   source ~/.bashrc
   ```
 
+  ```fish
+  # For fish
+  fish_add_path $HOME/go/bin
+  ```
+
   ```sh
-  # For macOS
+  # For macOS/zsh
   echo 'export PATH=$PATH:$HOME/.local/opt/go/bin' >> ~/.zshrc
   # Next, reload your shell configuration
   source ~/.zshrc


### PR DESCRIPTION
Add code block for adding `go/bin` to `$PATH` when using fish shell in troubleshooting section.