### PR TITLE
docs: Add instructions for fish shell configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,11 @@ After installing Golang, _open a new shell session_ and run `go version` to make
   # Next, reload your shell configuration
   source ~/.bashrc
   ```
-
+  ```sh
+  # For Linux/WSL(for fish shell)
+  echo 'set -gx PATH $PATH $HOME/go/bin' >> ~/.config/fish/config.fish
+  source ~/.config/fish/config.fish
+  ```
   ```sh
   # For macOS
   echo 'export PATH=$PATH:$HOME/.local/opt/go/bin' >> ~/.zshrc


### PR DESCRIPTION
The current README provides clear instructions for bash and zsh users, but fish shell requires a different syntax for environment variable configuration.

This PR adds equivalent instructions for fish users, ensuring they can correctly add $HOME/go/bin to their PATH and use the CLI without encountering command not found errors.