### PR TITLE
add fish to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,11 @@ After installing Golang, _open a new shell session_ and run `go version` to make
   source ~/.zshrc
   ```
 
+  ```sh
+  # For fish
+  fish_add_path $HOME/.local/opt/go/bin
+  ```
+
 ### 2. Install the Boot.dev CLI
 
 The following command will download, build, and install the `bootdev` command into your Go toolchain's `bin` directory. Go ahead and run it:
@@ -98,6 +103,11 @@ source ~/.bashrc
 echo 'export PATH=$PATH:$HOME/go/bin' >> ~/.zshrc
 # Next, reload your shell configuration
 source ~/.zshrc
+```
+
+```sh
+# For fish
+fish_add_path $HOME/go/bin
 ```
 
 ### 3. Login to the CLI


### PR DESCRIPTION
Add go installation instructions and troubleshooting for fish.

Thank you for your PRs:
https://github.com/bootdotdev/bootdev/pull/179
https://github.com/bootdotdev/bootdev/pull/176
https://github.com/bootdotdev/bootdev/pull/24

We reserve the right to remove fish instructions in the future. We don't want the readme to become bloated and supporting instructions for every shell or OS may impact the utility of the readme for majority of users on the big three.
