### PR TITLE
better display of errors

### DIFF
--- a/render/view.go
+++ b/render/view.go
@@ -150,13 +150,22 @@ func (m rootModel) View() string {
 		str.WriteString(green.Render("Return to your browser to continue with the next lesson.") + "\n\n")
 	} else if m.result == api.VerificationResultSlugNoop {
 		str.WriteString("\n\nTests failed! ❌")
-		str.WriteString(fmt.Sprintf("\n\nFailed Step: %v", m.failure.FailedStepIndex+1))
+		fmt.Fprintf(&str, "\n\nFailed Step: %v", m.failure.FailedStepIndex+1)
 		str.WriteString("\nError: " + m.failure.ErrorMessage + "\n")
 		str.WriteString("\nYou haven't passed, but you also haven't been penalized.\n\n")
 	} else if m.result == api.VerificationResultSlugFailure {
 		str.WriteString("\n\n" + red.Render("Tests failed! ❌"))
-		str.WriteString(red.Render(fmt.Sprintf("\n\nFailed Step: %v", m.failure.FailedStepIndex+1)))
-		str.WriteString(red.Render("\nError: "+m.failure.ErrorMessage) + "\n\n")
+		if m.failure != nil {
+			if m.failure.FailedStepIndex >= 0 && m.failure.FailedStepIndex < len(m.steps) {
+				fmt.Fprintf(&str, "%s", red.Render(fmt.Sprintf("\n\nFailed Command: %s", m.steps[m.failure.FailedStepIndex].step)))
+			}
+			fmt.Fprintf(&str, "%s", red.Render(fmt.Sprintf("\n\nFailed Step: %v", m.failure.FailedStepIndex+1)))
+			fmt.Fprintf(&str, "%s", red.Render("\nError: "+m.failure.ErrorMessage))
+		} else {
+			fmt.Fprintf(&str, "%s", red.Render("\n\nFailed Step: unknown"))
+			fmt.Fprintf(&str, "%s", red.Render("\nError: unknown"))
+		}
+		str.WriteString("\n\n")
 		currentDate := time.Now().Format("2006-01-02")
 		if strings.HasSuffix(currentDate, "04-01") {
 			str.WriteString(magenta.Render(fmt.Sprintf("This incident has been reported to your system administrator. [%s]\n", currentDate)))


### PR DESCRIPTION
Closes https://github.com/bootdotdev/go-api-gate/issues/8112

The first run is using this change. Note the `Failed Command: Running: go test -v`. The second run is what we currently have.

<img width="1184" height="1509" alt="image" src="https://github.com/user-attachments/assets/9a1a973d-c407-42a4-9677-39dc3ce03575" />
