### PR TITLE
fix bash completion install command

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -31,6 +31,7 @@ func Execute(currentVersion string) error {
 	info := version.FetchUpdateInfo(rootCmd.Version)
 	defer info.PromptUpdateIfAvailable()
 	ctx := version.WithContext(context.Background(), &info)
+	patchBashCompletionHelp()
 	return rootCmd.ExecuteContext(ctx)
 }
 
@@ -193,4 +194,22 @@ func requireAuth(cmd *cobra.Command, args []string) {
 
 	err = viper.WriteConfig()
 	promptLoginAndExitIf(err != nil)
+}
+
+// patchBashCompletionHelp adjusts Cobra's generated bash completion help.
+//
+// Cobra's default Linux example redirects into /etc/bash_completion.d, which
+// fails for non-root shells. Use sudo tee so only the file write is elevated.
+func patchBashCompletionHelp() {
+	rootCmd.InitDefaultCompletionCmd()
+
+	bashCmd, _, err := rootCmd.Find([]string{"completion", "bash"})
+	if err != nil || bashCmd == nil {
+		return
+	}
+
+	old := "bootdev completion bash > /etc/bash_completion.d/bootdev"
+	new := "bootdev completion bash | sudo tee /etc/bash_completion.d/bootdev > /dev/null"
+
+	bashCmd.Long = strings.Replace(bashCmd.Long, old, new, 1)
 }


### PR DESCRIPTION
## Summary

Fixes the Linux bash completion install example in the generated Cobra help text.

The previous command used shell redirection directly into `/etc/bash_completion.d/bootdev`, which usually fails for non-root users:

```bash
bootdev completion bash > /etc/bash_completion.d/bootdev
```

The updated command uses `sudo tee` so only the file write is elevated:

```bash
bootdev completion bash | sudo tee /etc/bash_completion.d/bootdev > /dev/null
```

## Testing

Ran:

```bash
go test ./...
go run . help completion bash
```

`go test ./...` passes. Verified that the Linux bash completion example now uses `sudo tee`.