### PR TITLE
expose baseURL to cli commands

### DIFF
--- a/checks/runner.go
+++ b/checks/runner.go
@@ -9,12 +9,10 @@ import (
 	"github.com/bootdotdev/bootdev/messages"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 )
 
 func CLIChecks(cliData api.CLIData, overrideBaseURL string, ch chan tea.Msg) (results []api.CLIStepResult) {
 	client := &http.Client{}
-	variables := make(map[string]string)
 	results = make([]api.CLIStepResult, len(cliData.Steps))
 
 	if cliData.BaseURLDefault == api.BaseURLOverrideRequired && overrideBaseURL == "" {
@@ -24,6 +22,11 @@ func CLIChecks(cliData api.CLIData, overrideBaseURL string, ch chan tea.Msg) (re
 	baseURL := overrideBaseURL
 	if overrideBaseURL == "" {
 		baseURL = cliData.BaseURLDefault
+	}
+	baseURL = strings.TrimSuffix(baseURL, "/")
+	variables := make(map[string]string)
+	if baseURL != "" {
+		variables["baseURL"] = baseURL
 	}
 
 	for i, step := range cliData.Steps {
@@ -35,12 +38,7 @@ func CLIChecks(cliData api.CLIData, overrideBaseURL string, ch chan tea.Msg) (re
 				NoPenaltyOnFail: step.NoPenaltyOnFail,
 			}
 		} else if step.HTTPRequest != nil {
-			finalBaseURL := baseURL
-			overrideURL := viper.GetString("override_base_url")
-			if overrideURL != "" {
-				finalBaseURL = overrideURL
-			}
-			fullURL := strings.Replace(step.HTTPRequest.Request.FullURL, api.BaseURLPlaceholder, finalBaseURL, 1)
+			fullURL := strings.Replace(step.HTTPRequest.Request.FullURL, api.BaseURLPlaceholder, baseURL, 1)
 			interpolatedURL := InterpolateVariables(fullURL, variables)
 
 			ch <- messages.StartStepMsg{

--- a/checks/runner_test.go
+++ b/checks/runner_test.go
@@ -1,12 +1,100 @@
 package checks
 
 import (
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	api "github.com/bootdotdev/bootdev/client"
 	"github.com/bootdotdev/bootdev/messages"
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/spf13/viper"
 )
+
+func TestCLIChecksInterpolatesResolvedBaseURLInCommands(t *testing.T) {
+	tests := []struct {
+		name            string
+		defaultBaseURL  string
+		overrideBaseURL string
+		want            string
+	}{
+		{
+			name:           "manifest default",
+			defaultBaseURL: "http://localhost:3000",
+			want:           "http://localhost:3000",
+		},
+		{
+			name:           "manifest default with trailing slash",
+			defaultBaseURL: "http://localhost:3000/",
+			want:           "http://localhost:3000",
+		},
+		{
+			name:            "configured override",
+			defaultBaseURL:  "http://localhost:3000",
+			overrideBaseURL: "http://localhost:4000/",
+			want:            "http://localhost:4000",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cliData := api.CLIData{
+				BaseURLDefault: tt.defaultBaseURL,
+				Steps: []api.CLIStep{{
+					CLICommand: &api.CLIStepCLICommand{
+						Command: `echo '${baseURL}'`,
+					},
+				}},
+			}
+			ch := make(chan tea.Msg, 10)
+
+			results := CLIChecks(cliData, tt.overrideBaseURL, ch)
+
+			if got := results[0].CLICommandResult.Stdout; got != tt.want {
+				t.Fatalf("command stdout = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCLIChecksUsesOverrideParameterForHTTPRequestPreview(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	previousOverride := viper.GetString("override_base_url")
+	viper.Set("override_base_url", "http://localhost:1")
+	t.Cleanup(func() {
+		viper.Set("override_base_url", previousOverride)
+	})
+
+	cliData := api.CLIData{
+		BaseURLDefault: "http://localhost:3000",
+		Steps: []api.CLIStep{{
+			HTTPRequest: &api.CLIStepHTTPRequest{
+				Request: api.HTTPRequest{
+					Method:  http.MethodGet,
+					FullURL: api.BaseURLPlaceholder + "/health",
+				},
+			},
+		}},
+	}
+	messageChannel := make(chan tea.Msg, 10)
+
+	results := CLIChecks(cliData, server.URL+"/", messageChannel)
+
+	startMessage, ok := (<-messageChannel).(messages.StartStepMsg)
+	if !ok {
+		t.Fatal("expected start step message")
+	}
+	if want := server.URL + "/health"; startMessage.URL != want {
+		t.Fatalf("preview URL = %q, want %q", startMessage.URL, want)
+	}
+	if got := results[0].HTTPRequestResult.StatusCode; got != http.StatusNoContent {
+		t.Fatalf("response status = %d, want %d", got, http.StatusNoContent)
+	}
+}
 
 func TestApplySubmissionResultsMarksAllStepsAndTestsPassedWhenNoFailure(t *testing.T) {
 	cliData := api.CLIData{Steps: []api.CLIStep{


### PR DESCRIPTION
Exposes the resolved lesson base URL to CLI command steps as `${baseURL}`, including configured overrides.